### PR TITLE
add show_viz parameter for openface2_ros node

### DIFF
--- a/launch/openface2_ros.launch
+++ b/launch/openface2_ros.launch
@@ -2,10 +2,12 @@
 
   <arg name="image_topic" default="/usb_cam/image_raw" />
   <arg name="publish_viz" default="true" />
+  <arg name="show_viz" default="true" />
 
   <node pkg="openface2_ros" name="openface2_ros" type="openface2_ros" output="screen">
       <param name="image_topic" value="$(arg image_topic)" type="str"/>
       <param name="publish_viz" value="$(arg publish_viz)" type="bool"/>
+      <param name="show_viz" value="$(arg show_viz)" type="bool"/>
   </node>
 
 </launch>


### PR DESCRIPTION
I added the `show_viz` flag to openface2_ros node and change the behavior of the node when the `publish_viz` flag is true.
After this PR,  you should set the `show_viz` flag to true to show a debug visualization.
You should set the `publish_viz` flag to true to publish a debug visualization image.

(無理して英語書くんじゃなかった)